### PR TITLE
Fix #1: Server now stops on receiving KillProcessRequest for gauge message

### DIFF
--- a/gauge-plugin/handler/handler.go
+++ b/gauge-plugin/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	gm "play-cdc/gauge_messages"
 	"play-cdc/repository"
 	"play-cdc/usecase"
@@ -132,4 +133,17 @@ func (h *handler) NotifySuiteResult(c context.Context, m *gm.SuiteExecutionResul
 
 	usecase.GenerateSpec()
 	return &gm.Empty{}, nil
+}
+
+func (h *handler) NotifyKillProcess(c context.Context, m *gm.KillProcessRequest) (*gm.Empty, error) {
+	if debug() {
+		fmt.Println("Received KillProcessRequest")
+	}
+	defer h.stopServer()
+	return &gm.Empty{}, nil
+}
+
+func (h *handler) stopServer() {
+	h.server.Stop()
+	os.Exit(0)
 }


### PR DESCRIPTION
#### Pull Request Details:
##### Description:
This pull request addresses the issue where the server did not stop upon receiving a KillProcessRequest for gauge messages. The server's behavior has been modified to ensure it stops as expected when such a request is received.

##### Issue
Close #1 

#### Notes for Release:
This update does not include a version increment. If this is to be released after merging, please ensure to update the version number in plugin.json accordingly. This task should be verified and carried out by the release manager.